### PR TITLE
fix(ui): fix coloring of line indices in topo image list

### DIFF
--- a/client/src/app/modules/topo-images/topo-image-list/topo-image-list.component.html
+++ b/client/src/app/modules/topo-images/topo-image-list/topo-image-list.component.html
@@ -170,7 +170,14 @@
                       <div
                         class="line-number"
                         [style]="{
-                          'background-color': linePath.line.color ?? undefined,
+                          '--arrow-color': linePath.line.color ?? undefined,
+                          '--arrow-text-color': textColor(linePath.line.color),
+                          '--arrow-highlight-color': highlightColor(
+                            linePath.line.color
+                          ),
+                          '--arrow-highlight-text-color': highlightColor(
+                            textColor(linePath.line.color)
+                          ),
                         }"
                       >
                         {{ i + 1 }}

--- a/client/src/app/modules/topo-images/topo-image-list/topo-image-list.component.ts
+++ b/client/src/app/modules/topo-images/topo-image-list/topo-image-list.component.ts
@@ -416,4 +416,7 @@ export class TopoImageListComponent implements OnInit {
       this.refreshData();
     });
   }
+
+  protected readonly textColor = textColor;
+  protected readonly highlightColor = highlightColor;
 }


### PR DESCRIPTION
Currently, only the background color is changed, disabling the hover effect and leading to black text regardless of the background color.