### PR TITLE
fix(ux): drawn lines are clickable when adding new lines

### DIFF
--- a/client/src/app/modules/shared/components/topo-image/topo-image.component.ts
+++ b/client/src/app/modules/shared/components/topo-image/topo-image.component.ts
@@ -206,29 +206,30 @@ export class TopoImageComponent implements OnInit {
     });
     background.fillPatternImage(this.backgroundImage);
     if (this.editorMode) {
-      background.on('click', (event) => {
-        event.cancelBubble = true;
-        this.imageClick.emit([
-          event.evt.offsetX * (1 / this.scale),
-          event.evt.offsetY * (1 / this.scale),
-        ]);
-      });
-      background.on('touchstart', (event) => {
-        event.cancelBubble = true;
-        const rect = (event.evt.target as HTMLElement).getBoundingClientRect();
-        const offsetX = event.evt.targetTouches[0].clientX - rect.left;
-        const offsetY = event.evt.targetTouches[0].clientY - rect.top;
-        this.imageClick.emit([
-          offsetX * (1 / this.scale),
-          offsetY * (1 / this.scale),
-        ]);
-      });
-      background.on('mouseenter', () => {
-        this.stage.container().style.cursor = 'pointer';
-      });
-      background.on('mouseleave', () => {
-        this.stage.container().style.cursor = 'default';
-      });
+      for (const layer of [background, this.lineLayer]) {
+        layer.on('click', (event) => {
+          event.cancelBubble = true;
+          this.imageClick.emit([
+            event.evt.offsetX * (1 / this.scale),
+            event.evt.offsetY * (1 / this.scale),
+          ]);
+        });
+        layer.on('touchstart', (event) => {
+          event.cancelBubble = true;
+          const rect = (
+            event.evt.target as HTMLElement
+          ).getBoundingClientRect();
+          const offsetX = event.evt.targetTouches[0].clientX - rect.left;
+          const offsetY = event.evt.targetTouches[0].clientY - rect.top;
+          this.imageClick.emit([
+            offsetX * (1 / this.scale),
+            offsetY * (1 / this.scale),
+          ]);
+        });
+        layer.on('mouseenter', () => {
+          this.stage.container().style.cursor = 'pointer';
+        });
+      }
     }
     this.fitStageIntoParentContainer();
     this.lineLayer.add(background);


### PR DESCRIPTION
In gyms, you often have several lines crossing each other. As (for some reason) click events are not propagated through the canvas layers, lines become a bit annoying to draw when they are dense.

@dorthrithil: I've removed the `mouseleave` event as I could not see a purpose for that, now that the whole canvas is clickable. However, I am not completely sure why it was there in the first place, so please check if this is fine.