### PR TITLE
fix(topo): fix grade distribution bar chart displayed total count

### DIFF
--- a/client/src/app/modules/shared/components/grade-distribution-bar-chart/grade-distribution-bar-chart.component.html
+++ b/client/src/app/modules/shared/components/grade-distribution-bar-chart/grade-distribution-bar-chart.component.html
@@ -11,7 +11,7 @@
     ></p-chart>
     <div class="total">
       {{ t("totalLines") }}:
-      {{ chartDataElement.totalCount - chartDataElement.projectCount }}
+      {{ chartDataElement.totalCount }}
       <span *ngIf="!excludeProjects">
         ({{ t("plusXProjects", { projects: chartDataElement.projectCount }) }})
       </span>


### PR DESCRIPTION
The project count was wrongly subtracted from the total count leading to too small numbers. This is now fixed.