### PR TITLE
fix(search): change elliptical search item avatars to circular avatars

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,59 +1,44 @@
 module.exports = {
-  branches: [
-    { name: "main" },
-    { name: "next", prerelease: true }
-  ],
-  tagFormat: "v${version}",
-  plugins: [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        releaseRules: [
-          { type: "style", release: "patch" }
-        ]
-      }
+    branches: [
+        {name: "main"},
+        {name: "next", prerelease: true}
     ],
-    [
-      "@semantic-release/release-notes-generator",
-      {
-        writerOpts: {
-          transform: (commit, context) => {
-            if (commit.type === "style") {
-              return {
-                ...commit,
-                type: "Style Changes"
-              };
+    tagFormat: "v${version}",
+    plugins: [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                releaseRules: [
+                    {type: "style", release: "patch"}
+                ]
             }
-            return commit;
-          }
-        }
-      }
-    ],
-    [
-      "@semantic-release/npm",
-      { npmPublish: false, pkgRoot: "." }
-    ],
-    [
-      "@semantic-release/npm",
-      { npmPublish: false, pkgRoot: "client" }
-    ],
-    [
-      "@semantic-release/npm",
-      { npmPublish: false, pkgRoot: "server" }
-    ],
-    "@semantic-release/changelog",
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        assets: [
-          "package.json",
-          "client/package.json",
-          "server/package.json",
-          "CHANGELOG.md"
         ],
-        message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
+        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/npm",
+            {npmPublish: false, pkgRoot: "."}
+        ],
+        [
+            "@semantic-release/npm",
+            {npmPublish: false, pkgRoot: "client"}
+        ],
+        [
+            "@semantic-release/npm",
+            {npmPublish: false, pkgRoot: "server"}
+        ],
+        "@semantic-release/changelog",
+        "@semantic-release/github",
+        [
+            "@semantic-release/git",
+            {
+                assets: [
+                    "package.json",
+                    "client/package.json",
+                    "server/package.json",
+                    "CHANGELOG.md"
+                ],
+                message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+            }
+        ]
     ]
-  ]
 };


### PR DESCRIPTION
This is kind of a workaround to add the falsely worded commit. "style(search): change elliptical search item avatars to circular avatars" to the generated changelog. I mistook style commits for UI style, but they are meant for code style commits. I didn't want to bother rewording / rebasing the commit history, so this is the fix to include the message...