### PR TITLE
fix(core): set max width to content container

### DIFF
--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -52,6 +52,9 @@ body {
   padding: 3rem 6rem;
   height: 100%;
   width: 100%;
+  max-width: 110rem;
+  margin-left: auto;
+  margin-right: auto;
 
   @include m.on-mobile {
     padding: 0 0;


### PR DESCRIPTION
On large screens the content was taking 100% width which lead to a not very usable UI. This is now fixed with a max wisth on the content element.

Closes #645 