### PR TITLE
fix(topo): fix issue where line style description was wrapping below line name in topo image view

### DIFF
--- a/client/src/app/modules/topo-images/topo-image-list/topo-image-list.component.scss
+++ b/client/src/app/modules/topo-images/topo-image-list/topo-image-list.component.scss
@@ -113,7 +113,7 @@ lc-topo-image-list {
             justify-content: left;
             align-items: center;
             text-align: left;
-            flex-basis: 30%;
+            flex-basis: 20%;
 
             .grade-ellipsis {
               max-width: min-content;
@@ -123,7 +123,7 @@ lc-topo-image-list {
           .line-table-info-style {
             display: flex;
             align-items: center;
-            flex-basis: 30%;
+            flex-basis: 40%;
             padding-right: 0.5rem;
           }
         }


### PR DESCRIPTION
The issue was happening for certain display reslutions.

Closes #664 