### PR TITLE
fix(ascents): ascent lists do not contain wrong data anymore

### DIFF
--- a/client/src/app/modules/area/area-ascents/area-ascents.component.html
+++ b/client/src/app/modules/area/area-ascents/area-ascents.component.html
@@ -1,1 +1,1 @@
-<lc-ascent-list [areaId]="area?.id"></lc-ascent-list>
+<lc-ascent-list [areaId]="area?.id" [parentLoading]="!area"></lc-ascent-list>

--- a/client/src/app/modules/crag/crag-ascents/crag-ascents.component.html
+++ b/client/src/app/modules/crag/crag-ascents/crag-ascents.component.html
@@ -1,1 +1,1 @@
-<lc-ascent-list [cragId]="crag?.id"></lc-ascent-list>
+<lc-ascent-list [cragId]="crag?.id" [parentLoading]="!crag"></lc-ascent-list>

--- a/client/src/app/modules/line/line-ascents/line-ascents.component.html
+++ b/client/src/app/modules/line/line-ascents/line-ascents.component.html
@@ -1,4 +1,5 @@
 <lc-ascent-list
   [lineId]="line?.id"
   [disableGradeOrderAndFiltering]="true"
+  [parentLoading]="!line"
 ></lc-ascent-list>

--- a/client/src/app/modules/sector/sector-ascents/sector-ascents.component.html
+++ b/client/src/app/modules/sector/sector-ascents/sector-ascents.component.html
@@ -1,1 +1,1 @@
-<lc-ascent-list [sectorId]="sector?.id"></lc-ascent-list>
+<lc-ascent-list [sectorId]="sector?.id" [parentLoading]="!sector"></lc-ascent-list>

--- a/client/src/app/modules/sector/sector-ascents/sector-ascents.component.html
+++ b/client/src/app/modules/sector/sector-ascents/sector-ascents.component.html
@@ -1,1 +1,4 @@
-<lc-ascent-list [sectorId]="sector?.id" [parentLoading]="!sector"></lc-ascent-list>
+<lc-ascent-list
+  [sectorId]="sector?.id"
+  [parentLoading]="!sector"
+></lc-ascent-list>


### PR DESCRIPTION
The ascent lists could show wrong data when the parent object (e.g. a line) was not fully loaded when the initial ascents were fetched. The fetching of ascents is now deferred.

Closes #687 