### PR TITLE
fix: don't show gallery loading skeleton when no images are loading

### DIFF
--- a/client/src/app/modules/gallery/gallery/gallery.component.html
+++ b/client/src/app/modules/gallery/gallery/gallery.component.html
@@ -18,12 +18,12 @@
     <div
       class="col-12 md:col-6 xl:col-4"
       *ngFor="
-        let _ of !(
-          loadingAdditionalPage === loadingStates.LOADING ||
-          loadingFirstPage === loadingStates.LOADING
-        )
+        let _ of
+        loadingAdditionalPage === loadingStates.LOADING
           ? [1, 2, 3]
-          : [1, 2, 3, 4, 5, 6]
+          : loadingFirstPage === loadingStates.LOADING
+            ? [1, 2, 3, 4, 5, 6]
+            : []
       "
     >
       <lc-gallery-image-skeleton></lc-gallery-image-skeleton>

--- a/client/src/app/modules/gallery/gallery/gallery.component.html
+++ b/client/src/app/modules/gallery/gallery/gallery.component.html
@@ -17,7 +17,13 @@
     </div>
     <div
       class="col-12 md:col-6 xl:col-4"
-      *ngFor="let _ of loadingAdditionalPage === loadingStates.LOADING ? [1, 2, 3] : loadingFirstPage === loadingStates.LOADING ? [1, 2, 3, 4, 5, 6] : []"
+      *ngFor="
+        let _ of loadingAdditionalPage === loadingStates.LOADING
+          ? [1, 2, 3]
+          : loadingFirstPage === loadingStates.LOADING
+            ? [1, 2, 3, 4, 5, 6]
+            : []
+      "
     >
       <lc-gallery-image-skeleton></lc-gallery-image-skeleton>
     </div>

--- a/client/src/app/modules/gallery/gallery/gallery.component.html
+++ b/client/src/app/modules/gallery/gallery/gallery.component.html
@@ -17,14 +17,7 @@
     </div>
     <div
       class="col-12 md:col-6 xl:col-4"
-      *ngFor="
-        let _ of
-        loadingAdditionalPage === loadingStates.LOADING
-          ? [1, 2, 3]
-          : loadingFirstPage === loadingStates.LOADING
-            ? [1, 2, 3, 4, 5, 6]
-            : []
-      "
+      *ngFor="let _ of loadingAdditionalPage === loadingStates.LOADING ? [1, 2, 3] : loadingFirstPage === loadingStates.LOADING ? [1, 2, 3, 4, 5, 6] : []"
     >
       <lc-gallery-image-skeleton></lc-gallery-image-skeleton>
     </div>


### PR DESCRIPTION
Closes #680 