### PR TITLE
fix(topo): fix line path and topo image ordering if there exist archived lines and topo images 

### DIFF
--- a/server/src/resources/line_path_resources.py
+++ b/server/src/resources/line_path_resources.py
@@ -70,11 +70,13 @@ class UpdateLinePathOrder(MethodView):
     @check_auth_claims(moderator=True)
     def put(self, image_id):
         """
-        Changes the order index of line paths.
+        Changes the order index of line paths for unarchived lines for a specific topo image.
         """
         new_order = request.json
-        line_paths: List[LinePath] = LinePath.return_all(filter=lambda: LinePath.topo_image_id == image_id)
-
+        line_paths: List[LinePath] = LinePath.return_all(
+            filter=lambda: [LinePath.topo_image_id == image_id, LinePath.line.has(Line.archived.is_(False))],
+            options=db.joinedload(LinePath.line),
+        )
         if not validate_order_payload(new_order, line_paths):
             raise BadRequest("New order doesn't match the requirements of the data to order.")
 

--- a/server/src/resources/topo_image_resources.py
+++ b/server/src/resources/topo_image_resources.py
@@ -122,11 +122,13 @@ class UpdateTopoImageOrder(MethodView):
     @check_auth_claims(moderator=True)
     def put(self, area_slug):
         """
-        Changes the order index of topo images.
+        Changes the order index of topo images. Only works on unarchived topo images.
         """
         new_order = request.json
         area_id = Area.get_id_by_slug(area_slug)
-        topo_images: List[TopoImage] = TopoImage.return_all(filter=lambda: TopoImage.area_id == area_id)
+        topo_images: List[TopoImage] = TopoImage.return_all(
+            filter=lambda: [TopoImage.area_id == area_id, TopoImage.archived.is_(False)]
+        )
 
         if not validate_order_payload(new_order, topo_images):
             raise BadRequest("New order doesn't match the requirements of the data to order.")


### PR DESCRIPTION
Fixed #758 