### PR TITLE
fix(core): include avatars in non-reaction user-min payloads

### DIFF
--- a/server/src/marshmallow_schemas/base_entity_schema.py
+++ b/server/src/marshmallow_schemas/base_entity_schema.py
@@ -10,4 +10,4 @@ class BaseEntityMinSchema(ma.SQLAlchemySchema):
 class BaseEntitySchema(BaseEntityMinSchema):
     timeCreated = fields.DateTime(attribute="time_created")
     timeUpdated = fields.DateTime(attribute="time_updated")
-    createdBy = ma.Nested("UserMinSchema", attribute="created_by")
+    createdBy = ma.Nested("UserMinWithAvatarSchema", attribute="created_by")

--- a/server/src/marshmallow_schemas/gallery_image_schema.py
+++ b/server/src/marshmallow_schemas/gallery_image_schema.py
@@ -7,7 +7,7 @@ from marshmallow_schemas.tag_schema import tag_schema
 
 class GalleryImageSchema(ma.SQLAlchemySchema):
     id = fields.String()
-    createdBy = ma.Nested("UserMinSchema", attribute="created_by")
+    createdBy = ma.Nested("UserMinWithAvatarSchema", attribute="created_by")
     image = fields.Nested(file_schema, attribute="file")
     tags = fields.Nested(tag_schema, many=True)
 

--- a/server/tests/test_comment_resources.py
+++ b/server/tests/test_comment_resources.py
@@ -14,6 +14,8 @@ def test_create_comment_on_line(client, member_token):
     assert rv.status_code == 201
     res = rv.json
     assert res["message"] == "Nice climb!"
+    assert res.get("createdBy") is not None
+    assert "avatar" in res["createdBy"]
     assert res.get("rootId") is None
     assert res.get("isDeleted") in (False, None)
 
@@ -68,6 +70,9 @@ def test_get_comments_for_line(client):
     rv = client.get(f"/api/comments?object-type=Line&object-id={line_id}&page=1&per-page=100")
     assert rv.status_code == 200
     assert "items" in rv.json
+    if rv.json["items"]:
+        assert rv.json["items"][0].get("createdBy") is not None
+        assert "avatar" in rv.json["items"][0]["createdBy"]
 
 
 def test_cascade_delete_comments(client, moderator_token, member_token):

--- a/server/tests/test_gallery_resources.py
+++ b/server/tests/test_gallery_resources.py
@@ -1,8 +1,5 @@
-from uuid import uuid4
-
 from models.file import File
 from models.gallery_image import GalleryImage
-from models.tag import Tag
 from models.user import User
 
 
@@ -15,6 +12,8 @@ def test_successful_create_gallery_image(client, user_token):
     assert rv.status_code == 201
     res = rv.json
     assert res["image"]["id"] == str(image_id)
+    assert res.get("createdBy") is not None
+    assert "avatar" in res["createdBy"]
     assert res["tags"][0]["objectType"] == "User"
     assert res["tags"][0]["object"]["id"] == str(user.id)
     assert res["id"] is not None
@@ -28,7 +27,7 @@ def test_successful_create_gallery_image(client, user_token):
     assert res["items"][0]["id"] == expected_id
 
     # Check, that the image is not shown in the line gallery of e.g. superspreader
-    rv = client.get(f"/api/gallery?page=1&tag-object-type=Line&tag-object-slug=super-spreader")
+    rv = client.get("/api/gallery?page=1&tag-object-type=Line&tag-object-slug=super-spreader")
     assert rv.status_code == 200
     res = rv.json
     assert len(res["items"]) == 1
@@ -74,6 +73,8 @@ def test_get_gallery_images_for_line(client):
     assert rv.status_code == 200
     res = rv.json
     assert len(res["items"]) == 1
+    assert res["items"][0].get("createdBy") is not None
+    assert "avatar" in res["items"][0]["createdBy"]
     assert res["items"][0]["tags"][0]["objectType"] == "Line"
 
     rv = client.get("/api/gallery?page=1&tag-object-type=Line&tag-object-slug=treppe")


### PR DESCRIPTION
Switch non-reaction createdBy serialization to UserMinWithAvatarSchema and add regression tests to assert avatar presence in comment and gallery responses while keeping reactions on UserMinSchema.