### PR TITLE
feat(core): configure client and server Sentry via env vars

### DIFF
--- a/client/src/app/models/instance-settings.ts
+++ b/client/src/app/models/instance-settings.ts
@@ -25,6 +25,8 @@ export class InstanceSettings {
   maptilerApiKey: string;
   maxFileSize: number;
   maxImageSize: number;
+  sentryEnabled: boolean;
+  sentryDsn: string;
   gymMode: boolean;
   displayUserGrades: boolean;
   displayUserRatings: boolean;
@@ -66,6 +68,8 @@ export class InstanceSettings {
     instanceSettings.maptilerApiKey = payload.maptilerApiKey;
     instanceSettings.maxFileSize = payload.maxFileSize;
     instanceSettings.maxImageSize = payload.maxImageSize;
+    instanceSettings.sentryEnabled = payload.sentryEnabled;
+    instanceSettings.sentryDsn = payload.sentryDsn;
     instanceSettings.gymMode = payload.gymMode;
     instanceSettings.displayUserGrades = payload.displayUserGrades;
     instanceSettings.displayUserRatings = payload.displayUserRatings;

--- a/client/src/app/modules/core/app.config.ts
+++ b/client/src/app/modules/core/app.config.ts
@@ -53,6 +53,11 @@ import { MatomoInitializerService, provideMatomo } from 'ngx-matomo-client';
 import { provideTranslocoMessageformat } from '@jsverse/transloco-messageformat';
 import { LanguageService } from '../../services/core/language.service';
 import { de } from 'primelocale/js/de.js';
+import { InstanceSettings } from '../../models/instance-settings';
+import {
+  SENTRY_IGNORED_NETWORK_ERROR_PATTERNS,
+  shouldDropSentryEvent,
+} from '../../utility/sentry-network-error';
 
 /**
  * Transloco HTTP loader.
@@ -88,6 +93,7 @@ const initInstanceSettingsAndLanguage = (
     return instanceSettingsService.getInstanceSettings().pipe(
       map((instanceSettings) => {
         store.dispatch(updateInstanceSettings({ settings: instanceSettings }));
+        initSentryFromSettings(instanceSettings);
         return instanceSettings.language;
       }),
       concatMap(languageService.initApp.bind(languageService)),
@@ -115,6 +121,34 @@ const initMatomo = (
       }
     });
   };
+};
+
+/**
+ * Initializes Sentry from server env-driven settings (SENTRY_ENABLED / SENTRY_DSN).
+ */
+const initSentryFromSettings = (settings: InstanceSettings): void => {
+  if (!settings.sentryEnabled || !settings.sentryDsn) {
+    return;
+  }
+  // According to Sentry: DSNs are safe to keep public (public in client-side code anyway)
+  Sentry.init({
+    dsn: settings.sentryDsn,
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
+    ignoreErrors: SENTRY_IGNORED_NETWORK_ERROR_PATTERNS,
+    beforeSend(event, hint) {
+      if (shouldDropSentryEvent(event, hint)) {
+        return null;
+      }
+      return event;
+    },
+    tracesSampleRate: 1.0,
+    tracePropagationTargets: ['localhost', '127.0.0.1'],
+    replaysSessionSampleRate: 1.0,
+    replaysOnErrorSampleRate: 1.0,
+  });
 };
 
 export function localeFactory(): string {

--- a/client/src/app/ngrx/reducers/instance-settings.reducers.ts
+++ b/client/src/app/ngrx/reducers/instance-settings.reducers.ts
@@ -23,6 +23,8 @@ export interface InstanceSettingsState {
   maptilerApiKey: string;
   maxFileSize: number;
   maxImageSize: number;
+  sentryEnabled: boolean;
+  sentryDsn: string;
   gymMode: boolean;
   skippedHierarchyLayers: number;
   displayUserGrades: boolean;
@@ -52,6 +54,8 @@ export const initialInstanceSettingsState: InstanceSettingsState = {
   maptilerApiKey: null,
   maxFileSize: 0,
   maxImageSize: 0,
+  sentryEnabled: false,
+  sentryDsn: '',
   gymMode: false,
   skippedHierarchyLayers: 0,
   displayUserGrades: false,
@@ -84,6 +88,8 @@ const instanceSettingsReducer = createReducer(
     maptilerApiKey: action.settings.maptilerApiKey,
     maxFileSize: action.settings.maxFileSize,
     maxImageSize: action.settings.maxImageSize,
+    sentryEnabled: action.settings.sentryEnabled,
+    sentryDsn: action.settings.sentryDsn,
     gymMode: action.settings.gymMode,
     skippedHierarchyLayers: action.settings.skippedHierarchicalLayers,
     displayUserGrades: action.settings.displayUserGrades,

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -7,36 +7,9 @@ import ImageUploader from 'quill-image-uploader';
 import { Chart } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import BlotFormatter from 'quill-blot-formatter';
-import * as Sentry from '@sentry/angular';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/modules/core/app.config';
 import { CoreComponent } from './app/modules/core/core.component';
-import {
-  SENTRY_IGNORED_NETWORK_ERROR_PATTERNS,
-  shouldDropSentryEvent,
-} from './app/utility/sentry-network-error';
-
-if (environment.production) {
-  Sentry.init({
-    // According to Sentry: DSNs are safe to keep public (will be public anyway in the client-side code)
-    dsn: 'https://7f45d91681b814a38e39e42ae68f25db@o4507560433811456.ingest.de.sentry.io/4507560581595216',
-    integrations: [
-      Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration(),
-    ],
-    ignoreErrors: SENTRY_IGNORED_NETWORK_ERROR_PATTERNS,
-    beforeSend(event, hint) {
-      if (shouldDropSentryEvent(event, hint)) {
-        return null;
-      }
-      return event;
-    },
-    tracesSampleRate: 1.0,
-    tracePropagationTargets: ['localhost', '127.0.0.1'],
-    replaysSessionSampleRate: 1.0,
-    replaysOnErrorSampleRate: 1.0,
-  });
-}
 
 if (environment.production) {
   enableProdMode();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,8 @@ services:
       SMTP_PORT: ${SMTP_PORT}
       SMTP_TYPE: ${SMTP_TYPE}
       FRONTEND_HOST: ${FRONTEND_HOST}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENABLED: ${SENTRY_ENABLED:-}
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:5000/api/health" ]
       interval: 30s

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -21,8 +21,8 @@ This document provides an overview of the environment variables used in the serv
 | `S3_ACCESS_ENDPOINT`      | `string` (e.g., `http://localhost:9000`)                  | Endpoint for accessing object storage from the client (may differ from `S3_ENDPOINT`). |
 | `S3_ADDRESSING`           | `string` (`path`, `virtual`)                              | Addressing style for object storage (path-based or virtual-hosted).                    |
 | `FRONTEND_HOST`           | `string` (e.g., `http://localhost:4200`)                  | Base URL of the frontend application                                                   |
-| `SENTRY_DSN`              | `string`                                                  | Data Source Name (DSN) for Sentry error tracking.                                      |
-| `SENTRY_ENABLED`          | `boolean` (`true`, `false`)                               | Flag to enable or disable Sentry integration.                                          |
+| `SENTRY_DSN`              | `string`                                                  | Data Source Name (DSN) for Sentry error tracking (server + client).                    |
+| `SENTRY_ENABLED`          | `boolean` (`true`, `false`)                               | Enable or disable Sentry for server and client.                                        |
 | `SUPERADMIN_EMAIL`        | `string` (e.g., `admin@example.com`)                      | Email address of the initial superadmin user.                                          |
 | `SUPERADMIN_FIRSTNAME`    | `string`                                                  | First name of the initial superadmin user.                                             |
 | `SUPERADMIN_LASTNAME`     | `string`                                                  | Last name of the initial superadmin user.                                              |

--- a/helm/localcrag/README.md
+++ b/helm/localcrag/README.md
@@ -30,6 +30,9 @@ systemEmail: "noreply@example.com"
 # REQUIRED: Public URL of your frontend application (with trailing slash)
 server:
   frontendHost: "https://localcrag.example.com/"
+  # Optional: Sentry (disabled by default)
+  # sentryEnabled: true
+  # sentryDsn: "https://examplePublicKey@o0.ingest.sentry.io/0"
 
 # REQUIRED: S3 / MinIO configuration
 appS3:

--- a/helm/localcrag/templates/server.yaml
+++ b/helm/localcrag/templates/server.yaml
@@ -106,6 +106,13 @@ spec:
             - name: LOG_LEVEL
               value: "{{ .Values.server.logLevel }}"
 
+            {{- if .Values.server.sentryEnabled }}
+            - name: SENTRY_ENABLED
+              value: "True"
+            - name: SENTRY_DSN
+              value: {{ required "server.sentryDsn is required when server.sentryEnabled is true" .Values.server.sentryDsn | quote }}
+            {{- end }}
+
           readinessProbe:
             httpGet:
               path: /api/health

--- a/helm/localcrag/values.schema.json
+++ b/helm/localcrag/values.schema.json
@@ -62,6 +62,14 @@
           "type": "string",
           "enum": ["DEBUG", "INFO", "WARNING", "ERROR"],
           "description": "Application log level written to stdout"
+        },
+        "sentryEnabled": {
+          "type": "boolean",
+          "description": "Enable Sentry error tracking for server and client"
+        },
+        "sentryDsn": {
+          "type": "string",
+          "description": "Sentry DSN (required when sentryEnabled is true)"
         }
       }
     },

--- a/helm/localcrag/values.yaml
+++ b/helm/localcrag/values.yaml
@@ -32,6 +32,10 @@ server:
   frontendHost: ""
   # Application log level (DEBUG, INFO, WARNING, ERROR). Logs go to stdout for kubectl logs.
   logLevel: INFO
+  # Optional Sentry error tracking (server + client). When enabled, sentryDsn is required.
+  # Disabled by default (env var omitted so the app default False applies).
+  sentryEnabled: false
+  sentryDsn: ""
   resources:
     requests:
       cpu: 500m

--- a/server/README.md
+++ b/server/README.md
@@ -30,8 +30,8 @@ For the full local toolchain (Docker vs native, Husky, MinIO), see [docs/dev-too
     - `S3_BUCKET` S3 object storage bucket name
     - `S3_ACCESS_ENDPOINT` Access endpoint of the S3 object storage
     - `S3_ADDRESSING` S3 object storage addressing mode: `virtual` or `path`
-    - `SENTRY_DSN` DSN for Sentry error tracking
-    - `SENTRY_ENABLED` If set to True, Sentry will be enabled with the configured DSN
+    - `SENTRY_DSN` DSN for Sentry error tracking (used by server and exposed to the client)
+    - `SENTRY_ENABLED` If set to True, Sentry will be enabled with the configured DSN on server and client
     - `LOG_LEVEL` Application log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Defaults to `INFO`. Logs are written to stdout.
 - For configuring a local object storage, read `../docs/dev-tooling.md`. This is needed if you are working with fileupload in any way.
 - Now you are ready to set up the database of your local dev instance:

--- a/server/src/config/template.cfg
+++ b/server/src/config/template.cfg
@@ -20,3 +20,5 @@ S3_REGION = 'eu-central-1'
 S3_BUCKET = 'your-bucket'
 S3_ACCESS_ENDPOINT = 'http://127.0.0.1:9000'
 S3_ADDRESSING = 'path'
+SENTRY_DSN = ''
+SENTRY_ENABLED = False

--- a/server/src/resources/instance_settings_resources.py
+++ b/server/src/resources/instance_settings_resources.py
@@ -25,6 +25,8 @@ def add_fixed_instance_settings(payload):
     """
     payload["maxFileSize"] = current_app.config["MAX_FILE_SIZE"]
     payload["maxImageSize"] = current_app.config["MAX_IMAGE_SIZE"]
+    payload["sentryEnabled"] = current_app.config["SENTRY_ENABLED"]
+    payload["sentryDsn"] = current_app.config["SENTRY_DSN"]
     return payload
 
 

--- a/server/tests/test_instance_settings_resources.py
+++ b/server/tests/test_instance_settings_resources.py
@@ -31,6 +31,8 @@ def test_successful_get_instance_settings(client):
     assert res["maptilerApiKey"] == instance_settings.maptiler_api_key
     assert res["maxFileSize"] == 5
     assert res["maxImageSize"] == 4
+    assert res["sentryEnabled"] is False
+    assert res["sentryDsn"] == ""
     assert res["gymMode"] == instance_settings.gym_mode
     assert res["skippedHierarchicalLayers"] == instance_settings.skipped_hierarchical_layers
     assert res["displayUserGrades"] == instance_settings.display_user_grades
@@ -95,6 +97,8 @@ def test_successful_edit_instance_settings(client, moderator_token, any_file):
     assert res["maptilerApiKey"] == "maptiler"
     assert res["maxFileSize"] == 5
     assert res["maxImageSize"] == 4
+    assert res["sentryEnabled"] is False
+    assert res["sentryDsn"] == ""
     assert res["gymMode"] is True
     assert res["skippedHierarchicalLayers"] == instance_settings.skipped_hierarchical_layers
     assert res["displayUserRatings"] is True


### PR DESCRIPTION
Configure client and server Sentry config from SENTRY_DSN and SENTRY_ENABLED env vars
instead of a hardcoded client DSN. The server exposes them as read-only
sentryEnabled/sentryDsn on GET /api/instance-settings; the client initializes
Sentry from those values after bootstrap. Also wire the same options through
docker-compose and the Helm chart (server.sentryEnabled / server.sentryDsn).

Closes #586